### PR TITLE
Gracefully handle HTTP errors in SimSimi.com

### DIFF
--- a/main.py
+++ b/main.py
@@ -131,8 +131,12 @@ class WebhookHandler(webapp2.RequestHandler):
             reply('look at the top-right corner of your screen!')
         else:
             if getEnabled(chat_id):
-                resp1 = json.load(urllib2.urlopen('http://www.simsimi.com/requestChat?lc=en&ft=1.0&req=' + urllib.quote_plus(text.encode('utf-8'))))
-                back = resp1.get('res')
+                try:
+                    resp1 = json.load(urllib2.urlopen('http://www.simsimi.com/requestChat?lc=en&ft=1.0&req=' + urllib.quote_plus(text.encode('utf-8'))))
+                    back = resp1.get('res')
+                except urllib2.HTTPError, err:
+                    logging.error(err)
+                    back = str(err)
                 if not back:
                     reply('okay...')
                 elif 'I HAVE NO RESPONSE' in back:


### PR DESCRIPTION
Any HTTP error thrown in SimSimi.com will cause the application to crash. This will result in Telegram hitting our Google App Engine application continuously until it gets a response (causing the application to start up and crash over and over again, as long as there's a problem with the SimSimi site). To mitigate this "boot loop" and satiate the hungry Telegram, we will simply return the stringified message of the HTTP error as a bot response.
